### PR TITLE
Don't add `admin` to roles array (and in particular, don't add multiple)

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -91,7 +91,7 @@ module.exports = (robot) ->
     user = robot.brain.userForName(name)
     return msg.reply "#{name} does not exist" unless user?
     user.roles or= []
-    displayRoles = user.roles
+    displayRoles = [].concat user.roles
 
     if user.id.toString() in admins
       displayRoles.push('admin')


### PR DESCRIPTION
Right now, it seems that the last commit (related to the `displayRoles` var) made it so that now admin is added to the actual user object in the users hash. And since this wasn't expected behaviour of the person who made the change, there's no checking for doubles, so it adds a new array item every time a roles command is run.
