### PR TITLE
src/auth.coffee: use isAdmin function

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -56,7 +56,7 @@ module.exports = (robot) ->
 
     userRoles: (user) ->
       roles = []
-      if user? and user.id in admins
+      if user? and robot.auth.isAdmin user
         roles.push('admin')
       if user.roles?
         roles = roles.concat user.roles


### PR DESCRIPTION
because user.id isn't a string the comparison was not functioning
correctly - the admin list is an array of strings.
