### PR TITLE
Remove hipchat from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,8 @@ See [`src/auth.coffee`](src/auth.coffee) for full documentation.
 
 Add **hubot-auth** to your `package.json` file:
 
-```json
-"dependencies": {
-  "hubot": ">= 2.5.1",
-  "hubot-scripts": ">= 2.4.2",
-  "hubot-auth": ">= 0.0.0"
-}
+```
+npm install --save hubot-auth
 ```
 
 Add **hubot-auth** to your `external-scripts.json`:


### PR DESCRIPTION
The README includes a package.json that has `hubot-hipchat` in it. I think this could be confusing for users, if that's not the adapter they are using. I originally thought to just remove that, but that still leaves you with a snippet of dependencies that might not be accurate.

Then I remembered `npm install --save`, which updates package.json with the latest version for you. I think that's a better bet!
