### PR TITLE
Allow referring to self in the first-person for add/remove role commands

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -68,7 +68,8 @@ module.exports = (robot) ->
     unless robot.auth.isAdmin msg.message.user
       msg.reply "Sorry, only admins can assign roles."
     else
-      name    = msg.match[1].trim()
+      name = msg.match[1].trim()
+      if name.toLowerCase() is 'i' then name = msg.message.user.name
       newRole = msg.match[2].trim().toLowerCase()
 
       unless name.toLowerCase() in ['', 'who', 'what', 'where', 'when', 'why']
@@ -90,7 +91,8 @@ module.exports = (robot) ->
     unless robot.auth.isAdmin msg.message.user
       msg.reply "Sorry, only admins can remove roles."
     else
-      name    = msg.match[1].trim()
+      name = msg.match[1].trim()
+      if name.toLowerCase() is 'i' then name = msg.message.user.name
       newRole = msg.match[3].trim().toLowerCase()
 
       unless name.toLowerCase() in ['', 'who', 'what', 'where', 'when', 'why']

--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -64,13 +64,13 @@ module.exports = (robot) ->
 
   robot.auth = new Auth
 
-  robot.respond /@?(.+) has (["'\w: -_]+) role/i, (msg) ->
+  robot.respond /@?(.+) ha(s|ve) (["'\w: -_]+) role/i, (msg) ->
     unless robot.auth.isAdmin msg.message.user
       msg.reply "Sorry, only admins can assign roles."
     else
       name = msg.match[1].trim()
       if name.toLowerCase() is 'i' then name = msg.message.user.name
-      newRole = msg.match[2].trim().toLowerCase()
+      newRole = msg.match[3].trim().toLowerCase()
 
       unless name.toLowerCase() in ['', 'who', 'what', 'where', 'when', 'why']
         user = robot.brain.userForName(name)
@@ -87,13 +87,13 @@ module.exports = (robot) ->
             user.roles.push(newRole)
             msg.reply "OK, #{name} has the '#{newRole}' role."
 
-  robot.respond /@?(.+) does(n't| not) have (["'\w: -_]+) role/i, (msg) ->
+  robot.respond /@?(.+) do(n't|esn't|es)( not)? have (["'\w: -_]+) role/i, (msg) ->
     unless robot.auth.isAdmin msg.message.user
       msg.reply "Sorry, only admins can remove roles."
     else
       name = msg.match[1].trim()
       if name.toLowerCase() is 'i' then name = msg.message.user.name
-      newRole = msg.match[3].trim().toLowerCase()
+      newRole = msg.match[4].trim().toLowerCase()
 
       unless name.toLowerCase() in ['', 'who', 'what', 'where', 'when', 'why']
         user = robot.brain.userForName(name)

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -68,6 +68,13 @@ describe 'auth', ->
 
     adapter.receive(new TextMessage admin_user, "hubot: role-user has demo role")
 
+  it 'admin user successfully sets role in the first-person', (done) ->
+    adapter.on "reply", (envelope, strings) ->
+      expect(strings[0]).to.match /admin-user has the 'demo' role/i
+      done()
+
+    adapter.receive(new TextMessage admin_user, "hubot: I have demo role")
+
   it 'fail to add admin role via command', (done) ->
     adapter.on "reply", (envelope, strings) ->
       expect(strings[0]).to.match /sorry/i
@@ -81,6 +88,15 @@ describe 'auth', ->
       done()
 
     adapter.receive(new TextMessage admin_user, "hubot: role-user doesn't have admin role")
+
+  it 'admin user successfully removes role in the first-person', (done) ->
+    adapter.receive(new TextMessage admin_user, "hubot: admin-user has demo role")
+
+    adapter.on "reply", (envelope, strings) ->
+      expect(strings[0]).to.match /ha(s|ve) the 'demo' role/i
+      done()
+
+    adapter.receive(new TextMessage admin_user, "hubot: I don't have demo role")
 
   it 'successfully list multiple roles of admin user', (done) ->
     adapter.receive(new TextMessage admin_user, "hubot: admin-user has demo role")


### PR DESCRIPTION
Quite simply, allow "I" to refer to the user just like we do in the "what roles" command.