### PR TITLE
Improved regex for removing roles

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -87,7 +87,7 @@ module.exports = (robot) ->
             user.roles.push(newRole)
             msg.reply "OK, #{name} has the '#{newRole}' role."
 
-  robot.respond /@?(.+) do(n't|esn't|es)( not)? have (["'\w: -_]+) role/i, (msg) ->
+  robot.respond /@?(.+) do(n['’]t|esn['’]t|es)( not)? have (["'\w: -_]+) role/i, (msg) ->
     unless robot.auth.isAdmin msg.message.user
       msg.reply "Sorry, only admins can remove roles."
     else


### PR DESCRIPTION
Now correctly matches `doesn’t` as well as 'doesn't`.

Closes #17 