### PR TITLE
[does] limit to has v has|have to skirt response activation on doesnt

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -64,13 +64,13 @@ module.exports = (robot) ->
 
   robot.auth = new Auth
 
-  robot.respond /@?(.+) ha(s|ve) (["'\w: -_]+) role/i, (msg) ->
+  robot.respond /@?(.+) has (["'\w: -_]+) role/i, (msg) ->
     unless robot.auth.isAdmin msg.message.user
       msg.reply "Sorry, only admins can assign roles."
     else
       name = msg.match[1].trim()
       if name.toLowerCase() is 'i' then name = msg.message.user.name
-      newRole = msg.match[3].trim().toLowerCase()
+      newRole = msg.match[2].trim().toLowerCase()
 
       unless name.toLowerCase() in ['', 'who', 'what', 'where', 'when', 'why']
         user = robot.brain.userForName(name)


### PR DESCRIPTION
this p/r aims to eliminate the extraneous (and erroneous) extra message that looks something like:

```
John Doe doesn't does not exist
```

due to the "doesn't" directive also matching the "does" directive but with an unintended match pattern
(user name = `John Doe doesn't`)
