### PR TITLE
Fix failing tests

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -64,13 +64,13 @@ module.exports = (robot) ->
 
   robot.auth = new Auth
 
-  robot.respond /@?(.+) ha(s|ve) (["'\w: -_]+) role/i, (msg) ->
+  robot.respond /@?([^\s]+) ha(?:s|ve) (["'\w: -_]+) role/i, (msg) ->
     unless robot.auth.isAdmin msg.message.user
       msg.reply "Sorry, only admins can assign roles."
     else
       name = msg.match[1].trim()
       if name.toLowerCase() is 'i' then name = msg.message.user.name
-      newRole = msg.match[3].trim().toLowerCase()
+      newRole = msg.match[2].trim().toLowerCase()
 
       unless name.toLowerCase() in ['', 'who', 'what', 'where', 'when', 'why']
         user = robot.brain.userForName(name)
@@ -87,13 +87,13 @@ module.exports = (robot) ->
             user.roles.push(newRole)
             msg.reply "OK, #{name} has the '#{newRole}' role."
 
-  robot.respond /@?(.+) do(n['’]t|esn['’]t|es)( not)? have (["'\w: -_]+) role/i, (msg) ->
+  robot.respond /@?([^\s]+) (?:don['’]t|doesn['’]t|do not) have (["'\w: -_]+) role/i, (msg) ->
     unless robot.auth.isAdmin msg.message.user
       msg.reply "Sorry, only admins can remove roles."
     else
       name = msg.match[1].trim()
       if name.toLowerCase() is 'i' then name = msg.message.user.name
-      newRole = msg.match[4].trim().toLowerCase()
+      newRole = msg.match[2].trim().toLowerCase()
 
       unless name.toLowerCase() in ['', 'who', 'what', 'where', 'when', 'why']
         user = robot.brain.userForName(name)
@@ -107,7 +107,7 @@ module.exports = (robot) ->
           user.roles = (role for role in user.roles when role isnt newRole)
           msg.reply "OK, #{name} doesn't have the '#{newRole}' role."
 
-  robot.respond /what roles? do(es)? @?(.+) have\?*$/i, (msg) ->
+  robot.respond /what roles? do(es)? @?([^\s]+) have\?*$/i, (msg) ->
     name = msg.match[2].trim()
     if name.toLowerCase() is 'i' then name = msg.message.user.name
     user = robot.brain.userForName(name)

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -44,8 +44,9 @@ describe 'auth', ->
 
     done()
 
-  afterEach ->
+  afterEach (done) ->
     robot.shutdown()
+    done()
 
   it 'list admin users', (done) ->
     adapter.on "reply", (envelope, strings) ->
@@ -93,6 +94,9 @@ describe 'auth', ->
     adapter.receive(new TextMessage admin_user, "hubot: admin-user has demo role")
 
     adapter.on "reply", (envelope, strings) ->
+      if strings[0].match /OK, admin-user has .*demo/i
+        return
+
       expect(strings[0]).to.match /ha(s|ve) the 'demo' role/i
       done()
 
@@ -102,6 +106,9 @@ describe 'auth', ->
     adapter.receive(new TextMessage admin_user, "hubot: admin-user has demo role")
 
     adapter.on "reply", (envelope, strings) ->
+      if strings[0].match /OK, admin-user has .*demo/i
+        return
+
       expect(strings[0]).to.match(/following roles: .*admin/)
       expect(strings[0]).to.match(/following roles: .*demo/)
       done()


### PR DESCRIPTION
* Usernames no longer support spaces to prevent issues with regex
matching
* Simplified the role removal regex to prevent matching on "I doesn't
not have.."

This in conjunction with the fixes to the reply callback in the tests
resolved all remaining test failures.

Closes #21 