### PR TITLE
Allow users with space in username

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -66,9 +66,10 @@ module.exports = (robot) ->
   robot.auth = new Auth
 
 
-  robot.respond /@?([^\s]+) ha(?:s|ve) (["'\w: -_]+) role/i, (msg) ->
+  robot.respond /@?(.+) ha(?:s|ve) (["'\w: -_]+) role/i, (msg) ->
     name = msg.match[1].trim()
     if name.toLowerCase() is 'i' then name = msg.message.user.name
+    if name.match(/(.*)(?:don['’]t|doesn['’]t|do not|does not)/i) then return
 
     unless name.toLowerCase() in ['', 'who', 'what', 'where', 'when', 'why']
       unless robot.auth.isAdmin msg.message.user
@@ -90,7 +91,7 @@ module.exports = (robot) ->
             user.roles.push(newRole)
             msg.reply "OK, #{name} has the '#{newRole}' role."
 
-  robot.respond /@?([^\s]+) (?:don['’]t|doesn['’]t|do not) have (["'\w: -_]+) role/i, (msg) ->
+  robot.respond /@?(.+) (?:don['’]t|doesn['’]t|do not|does not) have (["'\w: -_]+) role/i, (msg) ->
     name = msg.match[1].trim()
     if name.toLowerCase() is 'i' then name = msg.message.user.name
 
@@ -111,7 +112,7 @@ module.exports = (robot) ->
           user.roles = (role for role in user.roles when role isnt newRole)
           msg.reply "OK, #{name} doesn't have the '#{newRole}' role."
 
-  robot.respond /what roles? do(es)? @?([^\s]+) have\?*$/i, (msg) ->
+  robot.respond /what roles? do(es)? @?(.+) have\?*$/i, (msg) ->
     name = msg.match[2].trim()
     if name.toLowerCase() is 'i' then name = msg.message.user.name
     user = robot.brain.userForName(name)

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -120,29 +120,28 @@ describe "auth", ->
         ]
 
   context "list assigned roles", ->
-    beforeEach ->
-        @room.user.say("alice", "hubot: alice has demo role").then =>
-          @room.user.say("alice", "hubot: amy has test role").then =>
-            @room.user.say "alice", "hubot: alice has test role"
-
     it "successfully list assigned roles", ->
-        @room.user.say("alice", "hubot: list assigned roles").then =>
-          expect(@room.messages).to.eql [
-            ["alice", "hubot: alice has demo role"]
-            ["hubot", "@alice OK, alice has the 'demo' role."]
-            ["alice", "hubot: amy has test role"]
-            ["hubot", "@alice OK, amy has the 'test' role."]
-            ["alice", "hubot: alice has test role"]
-            ["hubot", "@alice OK, alice has the 'test' role."]
-            ["alice", "hubot: list assigned roles"]
-            ["hubot", "@alice The following roles are available: demo, test"]
-          ]
+      @room.user.say("alice", "hubot: alice has demo role").then =>
+        @room.user.say("alice", "hubot: amy has test role").then =>
+          @room.user.say "alice", "hubot: alice has test role"
+            @room.user.say("alice", "hubot: list assigned roles").then =>
+              expect(@room.messages).to.eql [
+                ["alice", "hubot: alice has demo role"]
+                ["hubot", "@alice OK, alice has the 'demo' role."]
+                ["alice", "hubot: amy has test role"]
+                ["hubot", "@alice OK, amy has the 'test' role."]
+                ["alice", "hubot: alice has test role"]
+                ["hubot", "@alice OK, alice has the 'test' role."]
+                ["alice", "hubot: list assigned roles"]
+                ["hubot", "@alice The following roles are available: demo, test"]
+              ]
 
     it "successfully lists roles of user with space in name", ->
-      @room.user.say("amy", "hubot: what roles does jimmy jones have?").then =>
-        expect(@room.messages).to.eql [
-          ["alice", "hubot: jimmy jones has demo role"]
-          ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
-          ["amy", "hubot: what roles does jimmy jones have?"]
-          ["hubot", "@amy jimmy jones has the following roles: demo."]
-        ]
+      @room.user.say("alice", "hubot: jimmy jones has the demo role").then =>
+        @room.user.say("amy", "hubot: what roles does jimmy jones have?").then =>
+          expect(@room.messages).to.eql [
+            ["alice", "hubot: jimmy jones has demo role"]
+            ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
+            ["amy", "hubot: what roles does jimmy jones have?"]
+            ["hubot", "@amy jimmy jones has the following roles: demo."]
+          ]

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -37,6 +37,13 @@ describe "auth", ->
           ["hubot", "@alice OK, alice has the 'demo' role."]
         ]
 
+    it "admin user successfully sets role for user with space in name", ->
+      @room.user.say("alice", "hubot: jimmy jones has demo role").then =>
+        expect(@room.messages).to.eql [
+          ["alice", "hubot: jimmy jones has demo role"]
+          ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
+        ]
+
 
     it "fail to add admin role via command", ->
       @room.user.say("alice", "hubot: jimmy has admin role").then =>
@@ -69,6 +76,17 @@ describe "auth", ->
           ["alice", "hubot: jimmy doesn't have admin role"]
           ["hubot", "@alice Sorry, the 'admin' role can only be removed from the HUBOT_AUTH_ADMIN env variable."]
         ]
+
+
+    it "admin user successfully removes role from user with space", ->
+      @room.user.say("alice", "hubot: jimmy jones has demo role").then =>
+        @room.user.say("alice", "hubot: jimmy jones doesn't have demo role").then =>
+          expect(@room.messages).to.eql [
+            ["alice", "hubot: jimmy jones has demo role"]
+            ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
+            ["alice", "hubot: jimmy jones doesn't have demo role"]
+            ["hubot", "@alice OK, jimmy jones doesn't have the 'demo' role."]
+          ]
 
   context "what roles does <user> have", ->
     beforeEach ->
@@ -116,3 +134,12 @@ describe "auth", ->
             ["alice", "hubot: list assigned roles"]
             ["hubot", "@alice The following roles are available: demo, test"]
           ]
+
+    it "successfully lists roles of user with space in name", ->
+      @room.user.say("amy", "hubot: what roles does jimmy jones have?").then =?>
+        expect(@room.messages).to.eql [
+          ["alice", "hubot: jimmy jones has demo role"]
+          ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
+          ["amy", "hubot: what roles does jimmy jones have?"]
+          ["hubot", "@amy jimmy jones has the following roles: admin, demo."]
+        ]

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -123,7 +123,7 @@ describe "auth", ->
     it "successfully list assigned roles", ->
       @room.user.say("alice", "hubot: alice has demo role").then =>
         @room.user.say("alice", "hubot: amy has test role").then =>
-          @room.user.say "alice", "hubot: alice has test role"
+          @room.user.say("alice", "hubot: alice has test role").then =>
             @room.user.say("alice", "hubot: list assigned roles").then =>
               expect(@room.messages).to.eql [
                 ["alice", "hubot: alice has demo role"]

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -17,6 +17,9 @@ describe "auth", ->
     @room.robot.brain.userForId "amy",
       name: "amy"
 
+    @room.robot.brain.userForId "jimmy jones",
+      name: "jimmy jones"
+
   afterEach ->
     @room.destroy()
 

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -144,5 +144,5 @@ describe "auth", ->
           ["alice", "hubot: jimmy jones has demo role"]
           ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
           ["amy", "hubot: what roles does jimmy jones have?"]
-          ["hubot", "@amy jimmy jones has the following roles: admin, demo."]
+          ["hubot", "@amy jimmy jones has the following roles: demo."]
         ]

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -14,6 +14,9 @@ describe "auth", ->
     @room.robot.brain.userForId "jimmy",
       name: "jimmy"
 
+    @room.robot.brain.userForId "jimmy jones",
+      name: "jimmy jones"
+
     @room.robot.brain.userForId "amy",
       name: "amy"
 
@@ -23,96 +26,120 @@ describe "auth", ->
   context "<user> has <role> role", ->
 
     it "admin user successfully sets role", ->
-      @room.user.say("alice", "hubot: jimmy has demo role").then =>
-        expect(@room.messages).to.eql [
-          ["alice", "hubot: jimmy has demo role"]
-          ["hubot", "@alice OK, jimmy has the 'demo' role."]
-        ]
+      @room.user.say("alice", "hubot: jimmy has demo role")
+      expect(@room.messages).to.eql [
+        ["alice", "hubot: jimmy has demo role"]
+        ["hubot", "@alice OK, jimmy has the 'demo' role."]
+      ]
+
+    it "admin user successfully sets role with space in name", ->
+      @room.user.say("alice", "hubot: jimmy jones has demo role")
+      expect(@room.messages).to.eql [
+        ["alice", "hubot: jimmy jones has demo role"]
+        ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
+      ]
 
 
     it "admin user successfully sets role in the first-person", ->
-      @room.user.say("alice", "hubot: I have demo role").then =>
-        expect(@room.messages).to.eql [
-          ["alice", "hubot: I have demo role"]
-          ["hubot", "@alice OK, alice has the 'demo' role."]
-        ]
+      @room.user.say("alice", "hubot: I have demo role")
+      expect(@room.messages).to.eql [
+        ["alice", "hubot: I have demo role"]
+        ["hubot", "@alice OK, alice has the 'demo' role."]
+      ]
 
 
     it "fail to add admin role via command", ->
-      @room.user.say("alice", "hubot: jimmy has admin role").then =>
-        expect(@room.messages).to.eql [
-          ["alice", "hubot: jimmy has admin role"]
-          ["hubot", "@alice Sorry, the 'admin' role can only be defined in the HUBOT_AUTH_ADMIN env variable."]
-        ]
+      @room.user.say("alice", "hubot: jimmy has admin role")
+      expect(@room.messages).to.eql [
+        ["alice", "hubot: jimmy has admin role"]
+        ["hubot", "@alice Sorry, the 'admin' role can only be defined in the HUBOT_AUTH_ADMIN env variable."]
+      ]
 
     it "anon user fails to set role", ->
-      @room.user.say("amy", "hubot: jimmy has demo role").then =>
-        expect(@room.messages).to.eql [
-          ["amy", "hubot: jimmy has demo role"]
-          ["hubot", "@amy Sorry, only admins can assign roles."]
-        ]
+      @room.user.say("amy", "hubot: jimmy has demo role")
+      expect(@room.messages).to.eql [
+        ["amy", "hubot: jimmy has demo role"]
+        ["hubot", "@amy Sorry, only admins can assign roles."]
+      ]
 
   context "<user> doesn't have <role> role", ->
     it "admin user successfully removes role in the first-person", ->
-      @room.user.say("alice", "hubot: alice has demo role").then =>
-        @room.user.say("alice", "hubot: I don't have demo role").then =>
-          expect(@room.messages).to.eql [
-            ["alice", "hubot: alice has demo role"]
-            ["hubot", "@alice OK, alice has the 'demo' role."]
-            ["alice", "hubot: I don't have demo role"]
-            ["hubot", "@alice OK, alice doesn't have the 'demo' role."]
-          ]
+      @room.user.say("alice", "hubot: alice has demo role")
+      @room.user.say("alice", "hubot: I don't have demo role")
+      expect(@room.messages).to.eql [
+        ["alice", "hubot: alice has demo role"]
+        ["hubot", "@alice OK, alice has the 'demo' role."]
+        ["alice", "hubot: I don't have demo role"]
+        ["hubot", "@alice OK, alice doesn't have the 'demo' role."]
+      ]
+    it "admin user successfully removes role from user with space", ->
+      @room.user.say("alice", "hubot: jimmy jones has demo role")
+      @room.user.say("alice", "hubot: jimmy jones doesn't have demo role")
+      expect(@room.messages).to.eql [
+        ["alice", "hubot: jimmy jones has demo role"]
+        ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
+        ["alice", "hubot: jimmy jones doesn't have demo role"]
+        ["hubot", "@alice OK, jimmy jones doesn't have the 'demo' role."]
+      ]
 
     it "fail to remove admin role via command", ->
-      @room.user.say("alice", "hubot: jimmy doesn't have admin role").then =>
-        expect(@room.messages).to.eql [
-          ["alice", "hubot: jimmy doesn't have admin role"]
-          ["hubot", "@alice Sorry, the 'admin' role can only be removed from the HUBOT_AUTH_ADMIN env variable."]
-        ]
+      @room.user.say("alice", "hubot: jimmy doesn't have admin role")
+      expect(@room.messages).to.eql [
+        ["alice", "hubot: jimmy doesn't have admin role"]
+        ["hubot", "@alice Sorry, the 'admin' role can only be removed from the HUBOT_AUTH_ADMIN env variable."]
+      ]
 
   context "what roles does <user> have", ->
     beforeEach ->
       @room.user.say("alice", "hubot: alice has demo role")
 
     it "successfully list multiple roles of admin user", ->
-      @room.user.say("amy", "hubot: what roles does alice have?").then =>
-        expect(@room.messages).to.eql [
-          ["alice", "hubot: alice has demo role"]
-          ["hubot", "@alice OK, alice has the 'demo' role."]
-          ["amy", "hubot: what roles does alice have?"]
-          ["hubot", "@amy alice has the following roles: admin, demo."]
-        ]
+      @room.user.say("amy", "hubot: what roles does alice have?")
+      expect(@room.messages).to.eql [
+        ["alice", "hubot: alice has demo role"]
+        ["hubot", "@alice OK, alice has the 'demo' role."]
+        ["amy", "hubot: what roles does alice have?"]
+        ["hubot", "@amy alice has the following roles: admin, demo."]
+      ]
+    it "successfully lists roles of user with space in name", ->
+      @room.user.say("amy", "hubot: what roles does jimmy jones have?")
+      expect(@room.messages).to.eql [
+        ["alice", "hubot: jimmy jones has demo role"]
+        ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
+        ["amy", "hubot: what roles does jimmy jones have?"]
+        ["hubot", "@amy jimmy jones has the following roles: admin, demo."]
+      ]
 
   context "who has <role> role", ->
     it "list admin users", ->
-      @room.user.say("alice", "hubot: who has admin role?").then =>
-        expect(@room.messages).to.eql [
-          ["alice", "hubot: who has admin role?"]
-          ["hubot", "@alice The following people have the 'admin' role: alice"]
-        ]
+      @room.user.say("alice", "hubot: who has admin role?")
+      expect(@room.messages).to.eql [
+        ["alice", "hubot: who has admin role?"]
+        ["hubot", "@alice The following people have the 'admin' role: alice"]
+      ]
 
     it "list admin users using non-admin user", ->
-      @room.user.say("amy", "hubot: who has admin role?").then =>
-        expect(@room.messages).to.eql [
-          ["amy", "hubot: who has admin role?"]
-          ["hubot", "@amy The following people have the 'admin' role: alice"]
-        ]
+      @room.user.say("amy", "hubot: who has admin role?")
+      expect(@room.messages).to.eql [
+        ["amy", "hubot: who has admin role?"]
+        ["hubot", "@amy The following people have the 'admin' role: alice"]
+      ]
 
   context "list assigned roles", ->
     beforeEach ->
-        @room.user.say("alice", "hubot: alice has demo role").then =>
-          @room.user.say("alice", "hubot: amy has test role").then =>
-            @room.user.say "alice", "hubot: alice has test role"
+        @room.user.say("alice", "hubot: alice has demo role")
+        @room.user.say("alice", "hubot: amy has test role")
+        @room.user.say ("alice", "hubot: alice has test role")
 
     it "successfully list assigned roles", ->
-        @room.user.say("alice", "hubot: list assigned roles").then =>
-          expect(@room.messages).to.eql [
-            ["alice", "hubot: alice has demo role"]
-            ["hubot", "@alice OK, alice has the 'demo' role."]
-            ["alice", "hubot: amy has test role"]
-            ["hubot", "@alice OK, amy has the 'test' role."]
-            ["alice", "hubot: alice has test role"]
-            ["hubot", "@alice OK, alice has the 'test' role."]
-            ["alice", "hubot: list assigned roles"]
-            ["hubot", "@alice The following roles are available: demo, test"]
-          ]
+        @room.user.say("alice", "hubot: list assigned roles")
+        expect(@room.messages).to.eql [
+          ["alice", "hubot: alice has demo role"]
+          ["hubot", "@alice OK, alice has the 'demo' role."]
+          ["alice", "hubot: amy has test role"]
+          ["hubot", "@alice OK, amy has the 'test' role."]
+          ["alice", "hubot: alice has test role"]
+          ["hubot", "@alice OK, alice has the 'test' role."]
+          ["alice", "hubot: list assigned roles"]
+          ["hubot", "@alice The following roles are available: demo, test"]
+        ]

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -14,9 +14,6 @@ describe "auth", ->
     @room.robot.brain.userForId "jimmy",
       name: "jimmy"
 
-    @room.robot.brain.userForId "jimmy jones",
-      name: "jimmy jones"
-
     @room.robot.brain.userForId "amy",
       name: "amy"
 
@@ -26,120 +23,96 @@ describe "auth", ->
   context "<user> has <role> role", ->
 
     it "admin user successfully sets role", ->
-      @room.user.say("alice", "hubot: jimmy has demo role")
-      expect(@room.messages).to.eql [
-        ["alice", "hubot: jimmy has demo role"]
-        ["hubot", "@alice OK, jimmy has the 'demo' role."]
-      ]
-
-    it "admin user successfully sets role with space in name", ->
-      @room.user.say("alice", "hubot: jimmy jones has demo role")
-      expect(@room.messages).to.eql [
-        ["alice", "hubot: jimmy jones has demo role"]
-        ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
-      ]
+      @room.user.say("alice", "hubot: jimmy has demo role").then =>
+        expect(@room.messages).to.eql [
+          ["alice", "hubot: jimmy has demo role"]
+          ["hubot", "@alice OK, jimmy has the 'demo' role."]
+        ]
 
 
     it "admin user successfully sets role in the first-person", ->
-      @room.user.say("alice", "hubot: I have demo role")
-      expect(@room.messages).to.eql [
-        ["alice", "hubot: I have demo role"]
-        ["hubot", "@alice OK, alice has the 'demo' role."]
-      ]
+      @room.user.say("alice", "hubot: I have demo role").then =>
+        expect(@room.messages).to.eql [
+          ["alice", "hubot: I have demo role"]
+          ["hubot", "@alice OK, alice has the 'demo' role."]
+        ]
 
 
     it "fail to add admin role via command", ->
-      @room.user.say("alice", "hubot: jimmy has admin role")
-      expect(@room.messages).to.eql [
-        ["alice", "hubot: jimmy has admin role"]
-        ["hubot", "@alice Sorry, the 'admin' role can only be defined in the HUBOT_AUTH_ADMIN env variable."]
-      ]
+      @room.user.say("alice", "hubot: jimmy has admin role").then =>
+        expect(@room.messages).to.eql [
+          ["alice", "hubot: jimmy has admin role"]
+          ["hubot", "@alice Sorry, the 'admin' role can only be defined in the HUBOT_AUTH_ADMIN env variable."]
+        ]
 
     it "anon user fails to set role", ->
-      @room.user.say("amy", "hubot: jimmy has demo role")
-      expect(@room.messages).to.eql [
-        ["amy", "hubot: jimmy has demo role"]
-        ["hubot", "@amy Sorry, only admins can assign roles."]
-      ]
+      @room.user.say("amy", "hubot: jimmy has demo role").then =>
+        expect(@room.messages).to.eql [
+          ["amy", "hubot: jimmy has demo role"]
+          ["hubot", "@amy Sorry, only admins can assign roles."]
+        ]
 
   context "<user> doesn't have <role> role", ->
     it "admin user successfully removes role in the first-person", ->
-      @room.user.say("alice", "hubot: alice has demo role")
-      @room.user.say("alice", "hubot: I don't have demo role")
-      expect(@room.messages).to.eql [
-        ["alice", "hubot: alice has demo role"]
-        ["hubot", "@alice OK, alice has the 'demo' role."]
-        ["alice", "hubot: I don't have demo role"]
-        ["hubot", "@alice OK, alice doesn't have the 'demo' role."]
-      ]
-    it "admin user successfully removes role from user with space", ->
-      @room.user.say("alice", "hubot: jimmy jones has demo role")
-      @room.user.say("alice", "hubot: jimmy jones doesn't have demo role")
-      expect(@room.messages).to.eql [
-        ["alice", "hubot: jimmy jones has demo role"]
-        ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
-        ["alice", "hubot: jimmy jones doesn't have demo role"]
-        ["hubot", "@alice OK, jimmy jones doesn't have the 'demo' role."]
-      ]
+      @room.user.say("alice", "hubot: alice has demo role").then =>
+        @room.user.say("alice", "hubot: I don't have demo role").then =>
+          expect(@room.messages).to.eql [
+            ["alice", "hubot: alice has demo role"]
+            ["hubot", "@alice OK, alice has the 'demo' role."]
+            ["alice", "hubot: I don't have demo role"]
+            ["hubot", "@alice OK, alice doesn't have the 'demo' role."]
+          ]
 
     it "fail to remove admin role via command", ->
-      @room.user.say("alice", "hubot: jimmy doesn't have admin role")
-      expect(@room.messages).to.eql [
-        ["alice", "hubot: jimmy doesn't have admin role"]
-        ["hubot", "@alice Sorry, the 'admin' role can only be removed from the HUBOT_AUTH_ADMIN env variable."]
-      ]
+      @room.user.say("alice", "hubot: jimmy doesn't have admin role").then =>
+        expect(@room.messages).to.eql [
+          ["alice", "hubot: jimmy doesn't have admin role"]
+          ["hubot", "@alice Sorry, the 'admin' role can only be removed from the HUBOT_AUTH_ADMIN env variable."]
+        ]
 
   context "what roles does <user> have", ->
     beforeEach ->
       @room.user.say("alice", "hubot: alice has demo role")
 
     it "successfully list multiple roles of admin user", ->
-      @room.user.say("amy", "hubot: what roles does alice have?")
-      expect(@room.messages).to.eql [
-        ["alice", "hubot: alice has demo role"]
-        ["hubot", "@alice OK, alice has the 'demo' role."]
-        ["amy", "hubot: what roles does alice have?"]
-        ["hubot", "@amy alice has the following roles: admin, demo."]
-      ]
-    it "successfully lists roles of user with space in name", ->
-      @room.user.say("amy", "hubot: what roles does jimmy jones have?")
-      expect(@room.messages).to.eql [
-        ["alice", "hubot: jimmy jones has demo role"]
-        ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
-        ["amy", "hubot: what roles does jimmy jones have?"]
-        ["hubot", "@amy jimmy jones has the following roles: admin, demo."]
-      ]
-
-  context "who has <role> role", ->
-    it "list admin users", ->
-      @room.user.say("alice", "hubot: who has admin role?")
-      expect(@room.messages).to.eql [
-        ["alice", "hubot: who has admin role?"]
-        ["hubot", "@alice The following people have the 'admin' role: alice"]
-      ]
-
-    it "list admin users using non-admin user", ->
-      @room.user.say("amy", "hubot: who has admin role?")
-      expect(@room.messages).to.eql [
-        ["amy", "hubot: who has admin role?"]
-        ["hubot", "@amy The following people have the 'admin' role: alice"]
-      ]
-
-  context "list assigned roles", ->
-    beforeEach ->
-        @room.user.say("alice", "hubot: alice has demo role")
-        @room.user.say("alice", "hubot: amy has test role")
-        @room.user.say ("alice", "hubot: alice has test role")
-
-    it "successfully list assigned roles", ->
-        @room.user.say("alice", "hubot: list assigned roles")
+      @room.user.say("amy", "hubot: what roles does alice have?").then =>
         expect(@room.messages).to.eql [
           ["alice", "hubot: alice has demo role"]
           ["hubot", "@alice OK, alice has the 'demo' role."]
-          ["alice", "hubot: amy has test role"]
-          ["hubot", "@alice OK, amy has the 'test' role."]
-          ["alice", "hubot: alice has test role"]
-          ["hubot", "@alice OK, alice has the 'test' role."]
-          ["alice", "hubot: list assigned roles"]
-          ["hubot", "@alice The following roles are available: demo, test"]
+          ["amy", "hubot: what roles does alice have?"]
+          ["hubot", "@amy alice has the following roles: admin, demo."]
         ]
+
+  context "who has <role> role", ->
+    it "list admin users", ->
+      @room.user.say("alice", "hubot: who has admin role?").then =>
+        expect(@room.messages).to.eql [
+          ["alice", "hubot: who has admin role?"]
+          ["hubot", "@alice The following people have the 'admin' role: alice"]
+        ]
+
+    it "list admin users using non-admin user", ->
+      @room.user.say("amy", "hubot: who has admin role?").then =>
+        expect(@room.messages).to.eql [
+          ["amy", "hubot: who has admin role?"]
+          ["hubot", "@amy The following people have the 'admin' role: alice"]
+        ]
+
+  context "list assigned roles", ->
+    beforeEach ->
+        @room.user.say("alice", "hubot: alice has demo role").then =>
+          @room.user.say("alice", "hubot: amy has test role").then =>
+            @room.user.say "alice", "hubot: alice has test role"
+
+    it "successfully list assigned roles", ->
+        @room.user.say("alice", "hubot: list assigned roles").then =>
+          expect(@room.messages).to.eql [
+            ["alice", "hubot: alice has demo role"]
+            ["hubot", "@alice OK, alice has the 'demo' role."]
+            ["alice", "hubot: amy has test role"]
+            ["hubot", "@alice OK, amy has the 'test' role."]
+            ["alice", "hubot: alice has test role"]
+            ["hubot", "@alice OK, alice has the 'test' role."]
+            ["alice", "hubot: list assigned roles"]
+            ["hubot", "@alice The following roles are available: demo, test"]
+          ]

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -41,7 +41,7 @@ describe "auth", ->
         ]
 
     it "admin user successfully sets role for user with space in name", ->
-      @room.user.say("alice", "hubot: jimmy jones has demo role").then =>
+      @room.user.say("alice", "hubot: jimmy jones has demo role").then =>  
         expect(@room.messages).to.eql [
           ["alice", "hubot: jimmy jones has demo role"]
           ["hubot", "@alice OK, jimmy jones has the 'demo' role."]
@@ -139,7 +139,7 @@ describe "auth", ->
           ]
 
     it "successfully lists roles of user with space in name", ->
-      @room.user.say("amy", "hubot: what roles does jimmy jones have?").then =?>
+      @room.user.say("amy", "hubot: what roles does jimmy jones have?").then =>
         expect(@room.messages).to.eql [
           ["alice", "hubot: jimmy jones has demo role"]
           ["hubot", "@alice OK, jimmy jones has the 'demo' role."]

--- a/test/auth-test.coffee
+++ b/test/auth-test.coffee
@@ -137,7 +137,7 @@ describe "auth", ->
               ]
 
     it "successfully lists roles of user with space in name", ->
-      @room.user.say("alice", "hubot: jimmy jones has the demo role").then =>
+      @room.user.say("alice", "hubot: jimmy jones has demo role").then =>
         @room.user.say("amy", "hubot: what roles does jimmy jones have?").then =>
           expect(@room.messages).to.eql [
             ["alice", "hubot: jimmy jones has demo role"]


### PR DESCRIPTION
Ability for users to have space in their user name when assigning roles, with passing unit tests