### PR TITLE
QA-596

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/

--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -115,6 +115,8 @@ module.exports = (robot) ->
           msg.reply "OK, #{name} doesn't have the '#{newRole}' role."
 
   robot.respond /what roles? do(es)? @?(.+) have\?*$/i, (msg) ->
+    unless robot.auth.isAdmin msg.message.user
+        msg.reply "Sorry, only admins can run this command"
     name = msg.match[2].trim()
     if name.toLowerCase() is 'i' then name = msg.message.user.name
     user = robot.brain.userForName(name)
@@ -127,6 +129,8 @@ module.exports = (robot) ->
       msg.reply "#{name} has the following roles: #{userRoles.join(', ')}."
 
   robot.respond /who has (["'\w: -_]+) role\?*$/i, (msg) ->
+    unless robot.auth.isAdmin msg.message.user
+        msg.reply "Sorry, only admins can run this command"
     role = msg.match[1]
     userNames = robot.auth.usersWithRole(role) if role?
 
@@ -138,7 +142,7 @@ module.exports = (robot) ->
   robot.respond /list assigned roles/i, (msg) ->
     roles = []
     unless robot.auth.isAdmin msg.message.user
-        msg.reply "Sorry, only admins can list assigned roles."
+        msg.reply "Sorry, only admins can run this command"
     else
         for i, user of robot.brain.data.users when user.roles
             roles.push role for role in user.roles when role not in roles


### PR DESCRIPTION
As part of completion of story https://truemotion.atlassian.net/browse/QA-596. The hubot-auth library is modified to restrict the truebot user to use following commands until they have admin role.

truebot what roles do I have
truebot what roles does have
truebot who has role
truebot list assigned roles